### PR TITLE
feat: Add cronjob to update schemas

### DIFF
--- a/.github/actions/build-schemas/action.yaml
+++ b/.github/actions/build-schemas/action.yaml
@@ -1,0 +1,25 @@
+name: Build Schemas
+description: Gets new schemas from cluster
+runs:
+  using: composite
+  steps:
+    - name: Authenticate and set context
+      uses: redhat-actions/oc-login@v1
+      with:
+        openshift_server_url: ${{ inputs.OPENSHIFT_SERVER }}
+        openshift_token: ${{ inputs.OPENSHIFT_TOKEN }}
+        insecure_skip_tls_verify: true
+    - name: Update schemas
+      shell: bash
+      run: |
+        pip install openapi2jsonschema
+        cd $GITHUB_WORKSPACE
+        python build_schema.py -u $(oc whoami --show-server) -t $(oc whoami -t) -s STRICT
+    - name: Upload artifacts from generating schemas
+      uses: actions/upload-artifact@v3
+      with:
+        name: schemas-artifacts
+        path: |
+          schemas/
+          skip_kinds.txt
+        retention-days: 1

--- a/.github/workflows/update-schemas.yaml
+++ b/.github/workflows/update-schemas.yaml
@@ -1,0 +1,68 @@
+name: Update schemas in repository
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  update-store:
+    strategy:
+      matrix:
+        include:
+          - environment: infra
+            cluster_url: https://api.moc-infra.massopen.cloud:6443
+            cluster_secret: INFRA_SA_TOKEN
+          - environment: smaug
+            cluster_url: https://api.smaug.na.operate-first.cloud:6443
+            cluster_secret: SMAUG_SA_TOKEN
+          - environment: morty
+            cluster_url: https://api.morty.emea.operate-first.cloud:6443
+            cluster_secret: MORTY_SA_TOKEN
+          - environment: rick
+            cluster_url: https://api.rick.emea.operate-first.cloud:6443
+            cluster_secret: RICK_SA_TOKEN
+          - environment: balrog
+            cluster_url: https://api.balrog.aws.operate-first.cloud:6443
+            cluster_secret: BALROG_SA_TOKEN
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get schemas from cluster
+        uses: ./.github/actions/build-schemas
+        with:
+          OPENSHIFT_SERVER: ${{ matrix.cluster_url }}
+          OPENSHIFT_TOKEN: ${{ secrets[matrix.cluster_secret] }}
+        continue-on-error: true
+
+  prepare-pr:
+    runs-on: ubuntu-22.04
+    needs: [update-store]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Move to workspace folder
+        shell: bash
+        run: |
+          cd $GITHUB_WORKSPACE
+
+      - name: Download all workflow artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Move skip_kinds.txt to root folder
+        shell: bash
+        run: |
+          cp -r schemas-artifacts/* .
+          rm -rf schemas-artifacts
+
+      - name: Setup PR
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "chore: Generate schemas"
+          branch: generate-schemas
+          delete-branch: true
+          title: Generate schemas
+          body: |
+            This PR is automatically generated. It updates schemas in the repository.
+            More information on how the schemas are updated can be found in the [README](https://github.com/operate-first/schema-store/blob/main/README.md#acquiring-schemas).

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+kubeconfig.yaml


### PR DESCRIPTION
Uses service account tokens which are saved in the repository secrets of github `schema-store` repository
Part of: https://github.com/open-services-group/scrum/issues/6
Resolves https://github.com/open-services-group/scrum/issues/19