### PR TITLE
fix: Don't fail if no PR is needed

### DIFF
--- a/.github/workflows/update-schemas.yaml
+++ b/.github/workflows/update-schemas.yaml
@@ -70,9 +70,15 @@ jobs:
 
       - name: Apply lgtm and approved labels so prow can merge PR
         uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ steps.setup-pr.outputs.pull-request-number }}
         with:
           number: ${{ steps.setup-pr.outputs.pull-request-number }}
           labels: |
             lgtm
             approved
             ok-to-test
+
+      - name: Warn if no PR was created
+        if: ${{ !steps.setup-pr.outputs.pull-request-number }}
+        run: |
+          echo "::warning ::No PR was created"


### PR DESCRIPTION
Fixes: #25 

Run the failing step only if PR number is present and create a warning annotation otherwise. 

In case the `setup-pr` step fails, the whole workflow should error out right away, so this should not affect such scenarios...