### PR TITLE
wip: feat: Order artifacts by OCP version

### DIFF
--- a/.github/actions/build-schemas/action.yaml
+++ b/.github/actions/build-schemas/action.yaml
@@ -7,6 +7,9 @@ inputs:
   openshift_token:
     description: Openshift Bearer Token. Store in a secret.
     required: true
+  name:
+    description: Openshift Cluster identifier.
+    default: ocp
 runs:
   using: composite
   steps:
@@ -22,10 +25,15 @@ runs:
         pip install openapi2jsonschema
         cd $GITHUB_WORKSPACE
         python build_schema.py -u $(oc whoami --show-server) -t $(oc whoami -t) -s STRICT
+    - name: Format artifact name
+      shell: bash
+      id: artifact
+      run: |
+        echo "::set-output name=name::artifact-$(oc version -o json | jq '.openshiftVersion')-${{ inputs.name }}"
     - name: Upload artifacts from generating schemas
       uses: actions/upload-artifact@v3
       with:
-        name: schemas-artifacts
+        name: ${{ steps.artifact.outputs.name }}
         path: |
           schemas/
           skip_kinds.txt

--- a/.github/workflows/update-schemas.yaml
+++ b/.github/workflows/update-schemas.yaml
@@ -33,6 +33,7 @@ jobs:
         with:
           openshift_server_url: ${{ matrix.cluster_url }}
           openshift_token: ${{ secrets[matrix.cluster_secret] }}
+          name: ${{ matrix.environment }}
         continue-on-error: true
 
   prepare-pr:
@@ -53,8 +54,10 @@ jobs:
       - name: Move skip_kinds.txt to root folder
         shell: bash
         run: |
-          cp -r schemas-artifacts/* .
-          rm -rf schemas-artifacts
+          for i in $(ls -d artifact-* | sort -V); do
+            cp -r $i/* .
+          done
+          rm -rf artifact-*
 
       - name: Setup PR
         id: setup-pr


### PR DESCRIPTION
Resolves: #16 

1. Populate each cluster schema as a separate artifact with name `artifact-<OCP_VERSION>-<CLUSTER_NAME>`.
2. Propagate schemas to the repository from the oldest OCP version to the newest

Few notes:
- `jq` [is present in Ubuntu runners](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#tools)
- `sort -V` can sort files containing semver

WIP, I need to test this a bit more
